### PR TITLE
Ignore JetBrains IDE settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # storing .env files is forbidden
 *.env
+
+# Jetbrains project settings
+.idea


### PR DESCRIPTION
JetBrains IDEs adds `.idea` directory to the project root when accessed through one of their products. Ignore this directory so that developers using PyCharm do not inherit/commit to each-others settings.

Signed-off-by: fredlawl <fred@fredlawl.com>