### PR TITLE
Add Contribution Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ In order to checkout the code, and run it locally, the following steps are neede
    ```
 
    Anytime you change application code, kill the current container, and re run `docker-compose up --build`.
+
+# Contribution
+
+Read the [Contribution Guide](documentation/contribution.md)

--- a/documentation/contribution.md
+++ b/documentation/contribution.md
@@ -1,0 +1,70 @@
+# Contribution
+
+## Communication Platforms
+* [Hack Night (Meetup.com)](http://www.meetup.com/KCBrigade/)
+* [Slack](https://codeforkc.slack.com/) #taggingtracker (Show up to hack night
+ for access)
+
+## Issues
+Issues can be submitted [here](https://github.com/codeforkansascity/tagging_tracker_backend/issues).
+ To ensure the quality of issues and a timely fix, the following guidelines
+ include the following:
+
+### Problem Issues
+1. Issues should be clearly communicated, correct spelling and grammar helps.
+1. Issues should include any relevant log information pertaining to the
+ problem at hand (if applicable).
+1. Issues should include details to replicate the issue (if applicable).
+
+### Feature Requests
+Feature requests are **strongly** encouraged to be submitted as pull requests.
+ Otherwise, feature requests should be submitted with a title noting that the
+ issue submitted is a feature request.
+
+## Submitting Pull Requests
+Pull requests will be handled through github.com. To create a pull request,
+ simply fork the repository, make your change, and submit it
+ [here](https://github.com/codeforkansascity/tagging_tracker_backend/pulls).
+
+### Commit Guidelines
+In order to ensure a smooth submission, make sure to tick each of the
+ checkboxes. This is meant as a reference to ensure quality submissions.
+
+Often, pull requests are constructed with multiple commits. Each of the
+ following apply at a per-commit level.
+
+- [ ] **A commit has a clear and concise summary**
+
+A commit summary is synonymous with commit title.
+
+- [ ] **A commit has a message outlining the purpose of the commit**
+
+It's OK for the message of the commit to be a single sentence or the
+ same as the title so long as the message and purpose of the commit is clear.
+ Correct grammar is extremely helpful.
+
+Include in your messages any information directly pertaining to the issue
+ being solved at hand. If there's error messages from the app, include them
+ in the message. If there's an issue a commit corresponds to, then link that
+ issue into the message.
+
+- [ ] **A commit does not contain an error that breaks the Python interpreter**
+
+### Contributor Expectations
+Contributors are expected to make appropriate updates to their pull requests
+ as requested by the core team members or others in the community.
+
+### Core Team Member Expectations
+Though the projects core maintainers are busy people, they will try to put
+ forth the effort to review and or apply pull requests on a weekly basis.
+ This schedule will typically align
+ with [Hack Nights](http://www.meetup.com/KCBrigade/).
+
+### Become a Core Team Member
+Consistently show up to [Hack Nights](http://www.meetup.com/KCBrigade/)
+ and participate with the group. There might be wine, and it's a fun time all
+ around.
+
+## Release Schedule
+Periodic updates are likely to coincide with
+ [Hack Nights](http://www.meetup.com/KCBrigade/).


### PR DESCRIPTION
As pointed out in Issue #13, a contribution guide was missing from the project. Address the issue with this pull request.