### PR TITLE
Untrack docker-compose.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ In order to checkout the code, and run it locally, the following steps are neede
    AUTH0_SECRET=<Create your own auth0 or ask developers for it>
    SSL_MODE=disable
    ```
+1. Optionally, configure your own settings by creating a
+  [docker-composer.override.yml](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files)
+  file. See
+  [Docker Compose](https://docs.docker.com/compose/compose-file/) for a list
+  of additional settings. 
 
 1. After the following previous steps are setup, running the following command to run the application.
 


### PR DESCRIPTION
Sometimes developers like to configure their docker environments from the default. To achieve this, the docker compose configuration must be untracked so that developers are able to configure their settings to their specific environment. Rename the `docker-compose.yml` to `docker-compose.example.yml` to untrack the `docker-compose.yml` file from the repository. In addition to that, the second patch updates the README.md file to include an instruction for renaming the `docker-compose.example.yml`