### PR TITLE
Make URL trailing slashes optional

### DIFF
--- a/backend/urls.py
+++ b/backend/urls.py
@@ -3,13 +3,13 @@ from backend import views
 
 urlpatterns = [
     url(r'^$', views.index),
-    url(r'^index/$', views.index),
-    url(r'^address/(?P<pk>[0-9]+)/tags/$', views.address_tags),
-    url(r'^address/(?P<pk>[0-9]+)/$', views.address_detail),
-    url(r'^address/$', views.address_list),
-    url(r'^address/(?P<pk>[0-9]+)/$', views.address_detail),
+    url(r'^index/?$', views.index),
+    url(r'^address/(?P<pk>[0-9]+)/tags/?$', views.address_tags),
+    url(r'^address/(?P<pk>[0-9]+)/?$', views.address_detail),
+    url(r'^address/?$', views.address_list),
+    url(r'^address/(?P<pk>[0-9]+)/?$', views.address_detail),
     url(r'^address/address.csv', views.csv_address_export),
-    url(r'^tags/$', views.tag_list),
-    url(r'^tags/(?P<pk>[0-9]+)/$', views.tag_detail),
+    url(r'^tags/?$', views.tag_list),
+    url(r'^tags/(?P<pk>[0-9]+)/?$', views.tag_detail),
     url(r'^tags/tags.csv', views.csv_tag_export),
 ]


### PR DESCRIPTION
As defined in Issue #29, URLs without a trailing slash, when requested,
respond to the client with an unexpected 300-level status code. Fix this by
making the trailing slash in the URL patterns optional.

Signed-off-by: fredlawl <fred@fredlawl.com>