### PR TITLE
Add DB ports to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3'
 services:
   db:
     image: mdillon/postgis:9.6
+    ports:
+      - "5432:5432"
   web:
     build: .
     volumes:


### PR DESCRIPTION
docker-compose.yml, by default, bound the database service to the Postgres
port of 5432. The configuration didn't expose that port to the host
machine. This patch exposes the port to the host machine so that developers
may connect to the database directly.

Signed-off-by: Frederick Lawler <fred@fredlawl.com>