### PR TITLE
Add error logging to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ In order to checkout the code, and run it locally, the following steps are neede
    SSL_ROOT_CERT - The path of the SSL certificate. Defaults to empty string, and not used if SSL is disabled.
    AUTH0_CLIENTID - ClientID of the auth0 authentication engine.
    AUTH0_SECRET - Secret of the auth0 authentication engine.
+   LOG_LEVEL - Error/Reporting logging level. More information here https://docs.djangoproject.com/en/2.0/topics/logging/#configuring-logging
    ```
 
    To get you started and running locally, here is a local.env file you can use.
@@ -49,7 +50,9 @@ In order to checkout the code, and run it locally, the following steps are neede
    AUTH0_CLIENTID=<Create your own auth0 or ask developers for it>
    AUTH0_SECRET=<Create your own auth0 or ask developers for it>
    SSL_MODE=disable
+   LOG_LEVEL=DEBUG
    ```
+   
 1. Optionally, configure your own settings by creating a
   [docker-compose.override.yml](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files)
   file. See

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,7 @@ python3 manage.py migrate
 mkdir -p /code/logs/
 touch /code/logs/gunicorn.log
 touch /code/logs/access.log
+touch /code/logs/error.log
 tail -n 0 -f /code/logs/*.log &
 
 echo 'Starting Gunicorn.'
@@ -13,7 +14,7 @@ exec gunicorn tagging_tracker.wsgi:application \
     --name tagging_tracker \
     --bind unix:/nginx/tagging_tracker.sock \
     --workers 3 \
-    --log-level=info \
+    --log-level=debug \
     --log-file=/code/logs/gunicorn.log \
     --access-logfile=/code/logs/access.log &
 

--- a/tagging_tracker/settings.py
+++ b/tagging_tracker/settings.py
@@ -163,3 +163,24 @@ AUTH0 = {
     'AUTHORIZATION_EXTENSION': False,  # default to False
     # 'USERNAME_FIELD': 'sub',  # default username field in auth0 token scope to use as token user
 }
+
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler'
+        },
+        'file': {
+            'class': 'logging.FileHandler',
+            'filename': '/code/logs/error.log'
+        }
+    },
+    'loggers': {
+        '': {  # 'catch all' loggers by referencing it with the empty string
+            'handlers': ['console', 'file'],
+            'level': 'DEBUG',
+        },
+    },
+}

--- a/tagging_tracker/settings.py
+++ b/tagging_tracker/settings.py
@@ -180,7 +180,7 @@ LOGGING = {
     'loggers': {
         '': {  # 'catch all' loggers by referencing it with the empty string
             'handlers': ['console', 'file'],
-            'level': 'DEBUG',
+            'level': os.getenv('LOG_LEVEL', 'ERROR'),
         },
     },
 }


### PR DESCRIPTION
It is difficult to debug an application that does not produce any erorr
logging. Add error logging to project through an error file and
console output.

Signed-off-by: Frederick Lawler <fred@fredlawl.com>