### PR TITLE
Allow developers to edit files without restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     ports:
       - "5432:5432"
   web:
+    restart: always
     build: .
     volumes:
       - .:/code

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,7 +16,8 @@ exec gunicorn tagging_tracker.wsgi:application \
     --workers 3 \
     --log-level=debug \
     --log-file=/code/logs/gunicorn.log \
-    --access-logfile=/code/logs/access.log &
+    --access-logfile=/code/logs/access.log \
+    --reload &
 
 echo 'Starting nginx'
 exec service nginx start


### PR DESCRIPTION
In order to test updates to modified .py files in Django, the Docker container
must be restarted. This complicates development and makes it hard to quickly
test updates. Add in configuration that causes the server to reload
automatically on file edit so testing can be expedited.

This update requires a rebuild of the docker container via
docker-compose up --build.

Signed-off-by: Frederick Lawler <fred@fredlawl.com>