### PR TITLE
Include link to virtualenv install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Secondly you can use [docker-compose](#docker-compose-instructions).
 
 These instructions assume you already have a virtualenv setup with a python 3.6 distribution.
 
+>NOTE: [This tutorial](https://docs.python-guide.org/dev/virtualenvs/)
+>provides good information on setting up a virtualenv for those that are
+>unfamiliar with setting it up.
+
 1. Run the following commands
 
 ```bash


### PR DESCRIPTION
New python developers may be unaware of settingup a virtualenv, add a
link to the README to provide instructions on setting it up.

Signed-off-by: Frederick Lawler <fred@fredlawl.com>